### PR TITLE
CORE-9190 Add input/output iRODS ticket support for submissions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor/
+.idea

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -127,6 +127,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "22a0e03ec09cfee364f686abea9d21e87407fdfa3f5af5754d84d94382a82931"
+  inputs-digest = "dae34d62022f072d5cc8928b1973e611f18c8bf045be77c2a63f8ec252d264b8"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -28,6 +28,10 @@
   name = "github.com/pkg/errors"
   version = "0.8.0"
 
+[[constraint]]
+  name = "github.com/cyverse-de/configurate"
+  version = "0.2.1"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/condor.go
+++ b/condor.go
@@ -15,6 +15,23 @@ type CondorJobSubmissionBuilder struct {
 // Build is where the the iplant.cmd, config, and job files are actually written
 // out for submissions to the local HTCondor cluster.
 func (b CondorJobSubmissionBuilder) Build(submission *model.Job, dirPath string) (string, error) {
+	var err error
+
+	templateFields := OtherTemplateFields{TicketPathListHeader: b.cfg.GetString("tickets_path_list.file_identifier")}
+	templateModel := TemplatesModel{
+		submission,
+		templateFields,
+	}
+
+	submission.OutputTicketFile, err = generateOutputTicketList(dirPath, templateModel)
+	if err != nil {
+		return "", err
+	}
+
+	submission.InputTicketsFile, err = generateInputTicketList(dirPath, templateModel)
+	if err != nil {
+		return "", err
+	}
 
 	// Generate the submission file.
 	submitFilePath, err := generateFile(dirPath, "iplant.cmd", condorSubmissionTemplate, submission)
@@ -35,6 +52,24 @@ func (b CondorJobSubmissionBuilder) Build(submission *model.Job, dirPath string)
 	}
 
 	return submitFilePath, nil
+}
+
+func generateOutputTicketList(dirPath string, submission TemplatesModel) (string, error) {
+	if submission.OutputDirTicket != "" {
+		// Generate the output ticket path list file.
+		return generateFile(dirPath, "output_ticket.list", outputTicketListTemplate, submission)
+	}
+
+	return "", nil
+}
+
+func generateInputTicketList(dirPath string, submission TemplatesModel) (string, error) {
+	if len(submission.FilterInputsWithTickets()) > 0 {
+		// Generate the input tickets path list file.
+		return generateFile(dirPath, "input_ticket.list", inputTicketListTemplate, submission)
+	}
+
+	return "", nil
 }
 
 func newCondorJobSubmissionBuilder(cfg *viper.Viper) JobSubmissionBuilder {

--- a/condor_templates.go
+++ b/condor_templates.go
@@ -5,7 +5,17 @@ import (
 	"text/template"
 
 	"github.com/pkg/errors"
+	"gopkg.in/cyverse-de/model.v2"
 )
+
+type OtherTemplateFields struct {
+	TicketPathListHeader string `json:"ticket_path_list_header"`
+}
+
+type TemplatesModel struct {
+	*model.Job
+	OtherTemplateFields
+}
 
 var (
 	// condorSubmissionTemplate is a *template.Template for the HTCondor submission file
@@ -13,6 +23,12 @@ var (
 
 	// condorJobConfigTemplate is the *template.Template for the job definition JSON
 	condorJobConfigTemplate *template.Template
+
+	// The *template.Template for a list of input files with iRODS download tickets.
+	inputTicketListTemplate *template.Template
+
+	// The *template.Template for the iRODS output dest with ticket.
+	outputTicketListTemplate *template.Template
 
 	// interappsSubmissionTemplate is a *template.Template fo the HTCondor
 	// submission files that define an interactive app job.
@@ -25,7 +41,8 @@ var (
 
 // SubmissionTemplateText is the text of the template for the HTCondor
 // submission file.
-const condorSubmissionTemplateText = `universe = vanilla
+const condorSubmissionTemplateText =
+`universe = vanilla
 executable = /usr/local/bin/road-runner
 rank = mips{{ if .UsesVolumes }}
 requirements = (HAS_HOST_MOUNTS == True){{ end }}
@@ -44,7 +61,7 @@ concurrency_limits = {{.UserIDForSubmission}}
 {{with $x := index .Steps 0}}+IpcExe = "{{$x.Component.Name}}"{{end}}
 {{with $x := index .Steps 0}}+IpcExePath = "{{$x.Component.Location}}"{{end}}
 should_transfer_files = YES
-transfer_input_files = iplant.cmd,config,job
+transfer_input_files = iplant.cmd,config,job{{if .OutputTicketFile}},{{.OutputTicketFile}}{{end}}{{if .InputTicketsFile}},{{.InputTicketsFile}}{{end}}
 transfer_output_files = workingvolume/logs/logs-stdout-output,workingvolume/logs/logs-stderr-output
 when_to_transfer_output = ON_EXIT_OR_EVICT
 notification = NEVER
@@ -53,7 +70,8 @@ queue
 
 // JobConfigTemplateText is the text of the template for the HTCondor submission
 // file.
-const condorJobConfigTemplateText = `amqp:
+const condorJobConfigTemplateText = `
+amqp:
     uri: {{.GetString "amqp.uri"}}
     exchange:
         name: {{.GetString "amqp.exchange.name"}}
@@ -67,7 +85,21 @@ condor:
     filter_files: "{{.GetString "condor.filter_files"}}"
 vault:
     token: "{{.GetString "vault.child_token.token"}}"
-    url: "{{.GetString "vault.url"}}"`
+    url: "{{.GetString "vault.url"}}"
+`
+
+// The text of the template for a list of input files with iRODS download tickets.
+const inputTicketListTemplateText =
+`{{.TicketPathListHeader}}
+{{range .FilterInputsWithTickets -}}
+{{.Ticket}},{{.IRODSPath}}
+{{end}}`
+
+// The text of the template for the iRODS output dest with ticket.
+const outputTicketListTemplateText =
+`{{.TicketPathListHeader}}
+{{.OutputDirTicket}},{{.OutputDir}}
+`
 
 const interappsSubmissionTemplateText = `universe = vanilla
 executable = /usr/local/bin/interapps-runner
@@ -115,6 +147,7 @@ k8s:
 
 func init() {
 	var err error
+
 	condorSubmissionTemplate, err = template.New("condor_submit").Parse(condorSubmissionTemplateText)
 	if err != nil {
 		log.Fatal(errors.Wrap(err, "failed to parse submission template text"))
@@ -123,6 +156,16 @@ func init() {
 	if err != nil {
 		log.Fatal(errors.Wrap(err, "failed to parse job config template text"))
 	}
+
+	inputTicketListTemplate, err = template.New("input_tickets").Parse(inputTicketListTemplateText)
+	if err != nil {
+		log.Fatal(errors.Wrap(err, "failed to parse input tickets template text"))
+	}
+	outputTicketListTemplate, err = template.New("output_ticket").Parse(outputTicketListTemplateText)
+	if err != nil {
+		log.Fatal(errors.Wrap(err, "failed to parse output ticket template text"))
+	}
+
 	interappsSubmissionTemplate, err = template.New("interapps_condor_submit").Parse(interappsSubmissionTemplateText)
 	if err != nil {
 		log.Fatal(errors.Wrap(err, "failed to parse interapps submission template text"))


### PR DESCRIPTION
This PR will add input/output iRODS ticket support for job submissions.

New templates for generating input and output ticket-path-list files have been added.
These path-list files will be created and submitted with the job only if tickets are set for either the inputs or the output folder in the submission JSON.

These file templates depend on a new `CondorJobSubmissionBuilder` config setting for the path list file headers: `tickets_path_list.file_identifier`

This PR replaces cyverse-de/condor-launcher#16 due to changes from cyverse-de/condor-launcher#17