### PR TITLE
Add a requirement for HAS_CYVERSE_ROAD_RUNNER to normal job template

### DIFF
--- a/condor_templates.go
+++ b/condor_templates.go
@@ -44,8 +44,8 @@ var (
 const condorSubmissionTemplateText =
 `universe = vanilla
 executable = /usr/local/bin/road-runner
-rank = mips{{ if .UsesVolumes }}
-requirements = (HAS_HOST_MOUNTS == True){{ end }}
+rank = mips
+requirements = (HAS_CYVERSE_ROAD_RUNNER =?= True){{ if .UsesVolumes }} && (HAS_HOST_MOUNTS =?= True){{ end }}
 arguments = --config config --job job
 output = script-output.log
 error = script-error.log


### PR DESCRIPTION
Fairly straightforward; I've configured the execute nodes in the de-2 environment to have this set. I've changed the setup to use `=?=` rather than `==` since that should behave a bit more nicely in the undefined case.

Once this is merged, I'll add a tag and update condor-launcher as well.