### PR TITLE
CORE-9192 Add InputPathListFile support to CondorJobSubmissionBuilder

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -115,8 +115,8 @@
 [[projects]]
   name = "gopkg.in/cyverse-de/model.v2"
   packages = ["."]
-  revision = "83170909c978fa6270a371f18b620175d76d73e4"
-  version = "v2.5"
+  revision = "b6fae6c0f89c0d1ee641eef0016db8d54ee3ca7a"
+  version = "v2.11"
 
 [[projects]]
   name = "gopkg.in/yaml.v2"
@@ -127,6 +127,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ecacbe349620471e166f2b0c2b868fa92f0867d44a2546aed773fdf80af64c40"
+  inputs-digest = "33adeb664bd017759cec65ce164d5591901dbef0c0f3a78f25158a0bc9b95c8e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -38,4 +38,4 @@
 
 [[constraint]]
   name = "gopkg.in/cyverse-de/model.v2"
-  version = "2.5.0"
+  version = "2.11.0"

--- a/condor.go
+++ b/condor.go
@@ -3,6 +3,7 @@ package jobs
 import (
 	"github.com/spf13/viper"
 	"gopkg.in/cyverse-de/model.v2"
+	"path/filepath"
 )
 
 // CondorJobSubmissionBuilder is responsible for writing out the iplant.cmd,
@@ -15,8 +16,6 @@ type CondorJobSubmissionBuilder struct {
 // Build is where the the iplant.cmd, config, and job files are actually written
 // out for submissions to the local HTCondor cluster.
 func (b CondorJobSubmissionBuilder) Build(submission *model.Job, dirPath string) (string, error) {
-	var err error
-
 	templateFields := OtherTemplateFields{
 		PathListHeader: b.cfg.GetString("path_list.file_identifier"),
 		TicketPathListHeader: b.cfg.GetString("tickets_path_list.file_identifier"),
@@ -26,20 +25,23 @@ func (b CondorJobSubmissionBuilder) Build(submission *model.Job, dirPath string)
 		templateFields,
 	}
 
-	submission.OutputTicketFile, err = generateOutputTicketList(dirPath, templateModel)
+	outputTicketFile, err := generateOutputTicketList(dirPath, templateModel)
 	if err != nil {
 		return "", err
 	}
+	submission.OutputTicketFile = filepath.Base(outputTicketFile)
 
-	submission.InputTicketsFile, err = generateInputTicketList(dirPath, templateModel)
+	inputTicketsFile, err := generateInputTicketList(dirPath, templateModel)
 	if err != nil {
 		return "", err
 	}
+	submission.InputTicketsFile = filepath.Base(inputTicketsFile)
 
-	submission.InputPathListFile, err = generateInputPathList(dirPath, templateModel)
+	inputPathListFile, err := generateInputPathList(dirPath, templateModel)
 	if err != nil {
 		return "", err
 	}
+	submission.InputPathListFile = filepath.Base(inputPathListFile)
 
 	// Generate the submission file.
 	submitFilePath, err := generateFile(dirPath, "iplant.cmd", condorSubmissionTemplate, submission)

--- a/condor_templates.go
+++ b/condor_templates.go
@@ -9,6 +9,7 @@ import (
 )
 
 type OtherTemplateFields struct {
+	PathListHeader       string `json:"path_list_header"`
 	TicketPathListHeader string `json:"ticket_path_list_header"`
 }
 
@@ -23,6 +24,9 @@ var (
 
 	// condorJobConfigTemplate is the *template.Template for the job definition JSON
 	condorJobConfigTemplate *template.Template
+
+	// The *template.Template for a list of input files without download tickets.
+	inputPathListTemplate *template.Template
 
 	// The *template.Template for a list of input files with iRODS download tickets.
 	inputTicketListTemplate *template.Template
@@ -61,7 +65,16 @@ concurrency_limits = {{.UserIDForSubmission}}
 {{with $x := index .Steps 0}}+IpcExe = "{{$x.Component.Name}}"{{end}}
 {{with $x := index .Steps 0}}+IpcExePath = "{{$x.Component.Location}}"{{end}}
 should_transfer_files = YES
-transfer_input_files = iplant.cmd,config,job{{if .OutputTicketFile}},{{.OutputTicketFile}}{{end}}{{if .InputTicketsFile}},{{.InputTicketsFile}}{{end}}
+transfer_input_files = iplant.cmd,config,job
+{{- if .OutputTicketFile -}}
+,{{.OutputTicketFile}}
+{{- end}}
+{{- if .InputTicketsFile -}}
+,{{.InputTicketsFile}}
+{{- end}}
+{{- if .InputPathListFile -}}
+,{{.InputPathListFile}}
+{{- end}}
 transfer_output_files = workingvolume/logs/logs-stdout-output,workingvolume/logs/logs-stderr-output
 when_to_transfer_output = ON_EXIT_OR_EVICT
 notification = NEVER
@@ -87,6 +100,13 @@ vault:
     token: "{{.GetString "vault.child_token.token"}}"
     url: "{{.GetString "vault.url"}}"
 `
+
+// The text of the template for a list of input files without download tickets.
+const inputPathListTemplateText =
+`{{.PathListHeader}}
+{{range .FilterInputsWithoutTickets -}}
+{{.IRODSPath}}
+{{end}}`
 
 // The text of the template for a list of input files with iRODS download tickets.
 const inputTicketListTemplateText =
@@ -155,6 +175,11 @@ func init() {
 	condorJobConfigTemplate, err = template.New("job_config").Parse(condorJobConfigTemplateText)
 	if err != nil {
 		log.Fatal(errors.Wrap(err, "failed to parse job config template text"))
+	}
+
+	inputPathListTemplate, err = template.New("input_path_list").Parse(inputPathListTemplateText)
+	if err != nil {
+		log.Fatal(errors.Wrap(err, "failed to parse input path list template text"))
 	}
 
 	inputTicketListTemplate, err = template.New("input_tickets").Parse(inputTicketListTemplateText)

--- a/test/osg_submission.json
+++ b/test/osg_submission.json
@@ -94,7 +94,7 @@
     "users:de-users"
   ],
   "app_name": "OSG Word Count Test",
-  "inputs_ticket_list": "input_ticket.list",
+  "input_ticket_list": "input_ticket.list",
   "output_ticket_list": "output_ticket.list",
   "config_file": "config.json"
 }

--- a/test/osg_submission_args.json
+++ b/test/osg_submission_args.json
@@ -101,7 +101,7 @@
     "users:de-users"
   ],
   "app_name": "OSG Word Count Test",
-  "inputs_ticket_list": "input_ticket.list",
+  "input_ticket_list": "input_ticket.list",
   "output_ticket_list": "output_ticket.list",
   "config_file": "config.json"
 }


### PR DESCRIPTION
This PR will add `InputPathListFile` support (added by cyverse-de/model#13) to `CondorJobSubmissionBuilder.Build`, which will create the `InputPathListFile` if the submission contains any inputs without download tickets, and submit this file in the Condor job submission.

A new template has been added that creates the `InputPathListFile`, which uses a new
`path_list.file_identifier` config setting.

Submitting the `InputPathListFile` will allow faster input downloads by using only 1 container to download all inputs (see cyverse-de/road-runner#16).