### PR TITLE
CORE-9297 + some misc stuff

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -115,8 +115,8 @@
 [[projects]]
   name = "gopkg.in/cyverse-de/model.v4"
   packages = ["."]
-  revision = "36b13d37bb4126f4b525a393512b0f420fea5ab4"
-  version = "v4.0"
+  revision = "51f67b05d6a692a14a233651ef2f5d49d1323133"
+  version = "v4.1"
 
 [[projects]]
   name = "gopkg.in/yaml.v2"
@@ -127,6 +127,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e00907efa25c2d029b5b9e17ad1b7ef2f5c8ad7cdb5b5bebdbe8e58e2b9deeb0"
+  inputs-digest = "e60c435c09e89b73117b88c93f709a075cd0ebc7289da579bf99f5c73e729d0a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -38,4 +38,4 @@
 
 [[constraint]]
   name = "gopkg.in/cyverse-de/model.v4"
-  version = "4.0.0"
+  version = "4.1.0"

--- a/condor_templates.go
+++ b/condor_templates.go
@@ -176,7 +176,10 @@ k8s:
     get-analysis-id:
         header: {{.GetString "k8s.get-analysis-id.header"}}`
 
+// bytesPerKiB is 2^10
 const bytesPerKiB = 1024
+
+// bytesPerMiB is 2^20
 const bytesPerMiB = 1048576
 
 // CondorBytes formats a number of bytes to a condor format (rounding up to the nearest KiB until it's at least 1MiB, then rounding up to the nearest MiB)

--- a/condor_templates.go
+++ b/condor_templates.go
@@ -49,7 +49,7 @@ var (
 const condorSubmissionTemplateText = `universe = vanilla
 executable = /usr/local/bin/road-runner
 rank = 100 - TotalLoadAvg
-requirements = (HAS_CYVERSE_ROAD_RUNNER =?= True){{ if .UsesVolumes }} && (HAS_HOST_MOUNTS =?= True){{ end }}{{- if .CPURequest }}
+requirements = HasDocker && (HAS_CYVERSE_ROAD_RUNNER =?= True){{ if .UsesVolumes }} && (HAS_HOST_MOUNTS =?= True){{ end }}{{- if .CPURequest }}
 request_cpus = {{ .CPURequest }}{{ end }}{{- if .MemoryRequest }}
 request_memory = {{ condorBytes .MemoryRequest }}{{ end }}{{- if .DiskRequest }}
 request_disk = {{ condorBytes .DiskRequest }}{{ end }}
@@ -123,7 +123,7 @@ const outputTicketListTemplateText = `{{.TicketPathListHeader}}
 const interappsSubmissionTemplateText = `universe = vanilla
 executable = /usr/local/bin/interapps-runner
 rank = 100 - TotalLoadAvg
-requirements = (HAS_CYVERSE_ROAD_RUNNER =?= True){{ if .UsesVolumes }} && (HAS_HOST_MOUNTS =?= True){{ end }}
+requirements = HasDocker && (HAS_CYVERSE_ROAD_RUNNER =?= True){{ if .UsesVolumes }} && (HAS_HOST_MOUNTS =?= True){{ end }}
 {{ if .CPURequest }}request_cpus = {{ .CPURequest }}{{ end }}
 {{ if .MemoryRequest }}request_memory = {{ condorBytes .MemoryRequest }}{{ end }}
 {{ if .DiskRequest }}request_disk = {{ condorBytes .DiskRequest }}{{ end }}

--- a/condor_templates.go
+++ b/condor_templates.go
@@ -176,22 +176,25 @@ k8s:
     get-analysis-id:
         header: {{.GetString "k8s.get-analysis-id.header"}}`
 
+const bytesPerKiB = 1024
+const bytesPerMiB = 1048576
+
 // CondorBytes formats a number of bytes to a condor format (rounding up to the nearest KiB until it's at least 1MiB, then rounding up to the nearest MiB)
 func CondorBytes(bytes int64) string {
-	if bytes < 1024 {
+	if bytes < bytesPerKiB {
 		return "1KB"
 	}
 
-	if bytes < 1048576 {
-		kb := bytes / 1024
-		if bytes%1024 > 0 {
+	if bytes < bytesPerMiB {
+		kb := bytes / bytesPerKiB
+		if bytes%bytesPerKiB > 0 {
 			kb = kb + 1
 		}
 		return fmt.Sprintf("%dKB", kb)
 	}
 
-	mb := bytes / 1048576
-	if bytes%1048576 > 0 {
+	mb := bytes / bytesPerMiB
+	if bytes%bytesPerMiB > 0 {
 		mb = mb + 1
 	}
 

--- a/condor_templates.go
+++ b/condor_templates.go
@@ -1,6 +1,7 @@
 package jobs
 
 import (
+	"fmt"
 	"log"
 	"text/template"
 
@@ -48,7 +49,10 @@ var (
 const condorSubmissionTemplateText = `universe = vanilla
 executable = /usr/local/bin/road-runner
 rank = 100 - TotalLoadAvg
-requirements = (HAS_CYVERSE_ROAD_RUNNER =?= True){{ if .UsesVolumes }} && (HAS_HOST_MOUNTS =?= True){{ end }}
+requirements = (HAS_CYVERSE_ROAD_RUNNER =?= True){{ if .UsesVolumes }} && (HAS_HOST_MOUNTS =?= True){{ end }}{{- if .CPURequest }}
+request_cpus = {{ .CPURequest }}{{ end }}{{- if .MemoryRequest }}
+request_memory = {{ condorBytes .MemoryRequest }}{{ end }}{{- if .DiskRequest }}
+request_disk = {{ condorBytes .DiskRequest }}{{ end }}
 arguments = --config config --job job
 output = script-output.log
 error = script-error.log
@@ -118,8 +122,11 @@ const outputTicketListTemplateText = `{{.TicketPathListHeader}}
 
 const interappsSubmissionTemplateText = `universe = vanilla
 executable = /usr/local/bin/interapps-runner
-rank = 100 - TotalLoadAvg{{ if .UsesVolumes }}
-requirements = (HAS_HOST_MOUNTS == True){{ end }}
+rank = 100 - TotalLoadAvg
+requirements = (HAS_CYVERSE_ROAD_RUNNER =?= True){{ if .UsesVolumes }} && (HAS_HOST_MOUNTS =?= True){{ end }}
+{{ if .CPURequest }}request_cpus = {{ .CPURequest }}{{ end }}
+{{ if .MemoryRequest }}request_memory = {{ condorBytes .MemoryRequest }}{{ end }}
+{{ if .DiskRequest }}request_disk = {{ condorBytes .DiskRequest }}{{ end }}
 arguments = --config config --job job
 output = script-output.log
 error = script-error.log
@@ -169,10 +176,36 @@ k8s:
     get-analysis-id:
         header: {{.GetString "k8s.get-analysis-id.header"}}`
 
+// CondorBytes formats a number of bytes to a condor format (rounding up to the nearest KiB until it's at least 1MiB, then rounding up to the nearest MiB)
+func CondorBytes(bytes int64) string {
+	if bytes < 1024 {
+		return "1KB"
+	}
+
+	if bytes < 1048576 {
+		kb := bytes / 1024
+		if bytes%1024 > 0 {
+			kb = kb + 1
+		}
+		return fmt.Sprintf("%dKB", kb)
+	}
+
+	mb := bytes / 1048576
+	if bytes%1048576 > 0 {
+		mb = mb + 1
+	}
+
+	return fmt.Sprintf("%dMB", mb)
+}
+
 func init() {
 	var err error
 
-	condorSubmissionTemplate, err = template.New("condor_submit").Parse(condorSubmissionTemplateText)
+	funcMap := template.FuncMap{
+		"condorBytes": CondorBytes,
+	}
+
+	condorSubmissionTemplate, err = template.New("condor_submit").Funcs(funcMap).Parse(condorSubmissionTemplateText)
 	if err != nil {
 		log.Fatal(errors.Wrap(err, "failed to parse submission template text"))
 	}
@@ -195,7 +228,7 @@ func init() {
 		log.Fatal(errors.Wrap(err, "failed to parse output ticket template text"))
 	}
 
-	interappsSubmissionTemplate, err = template.New("interapps_condor_submit").Parse(interappsSubmissionTemplateText)
+	interappsSubmissionTemplate, err = template.New("interapps_condor_submit").Funcs(funcMap).Parse(interappsSubmissionTemplateText)
 	if err != nil {
 		log.Fatal(errors.Wrap(err, "failed to parse interapps submission template text"))
 	}

--- a/condor_templates_test.go
+++ b/condor_templates_test.go
@@ -107,7 +107,7 @@ func TestGenerateCondorSubmit(t *testing.T) {
 	expected := `universe = vanilla
 executable = /usr/local/bin/road-runner
 rank = 100 - TotalLoadAvg
-requirements = (HAS_CYVERSE_ROAD_RUNNER =?= True) && (HAS_HOST_MOUNTS =?= True)
+requirements = HasDocker && (HAS_CYVERSE_ROAD_RUNNER =?= True) && (HAS_HOST_MOUNTS =?= True)
 request_cpus = 4.5
 request_memory = 2048MB
 request_disk = 2048MB
@@ -147,7 +147,7 @@ func TestGenerateCondorSubmitGroup(t *testing.T) {
 	expected := `universe = vanilla
 executable = /usr/local/bin/road-runner
 rank = 100 - TotalLoadAvg
-requirements = (HAS_CYVERSE_ROAD_RUNNER =?= True) && (HAS_HOST_MOUNTS =?= True)
+requirements = HasDocker && (HAS_CYVERSE_ROAD_RUNNER =?= True) && (HAS_HOST_MOUNTS =?= True)
 request_cpus = 4.5
 request_memory = 2048MB
 request_disk = 2048MB
@@ -186,7 +186,7 @@ func TestGenerateCondorSubmitNoVolumes(t *testing.T) {
 	expected := `universe = vanilla
 executable = /usr/local/bin/road-runner
 rank = 100 - TotalLoadAvg
-requirements = (HAS_CYVERSE_ROAD_RUNNER =?= True)
+requirements = HasDocker && (HAS_CYVERSE_ROAD_RUNNER =?= True)
 request_memory = 2KB
 arguments = --config config --job job
 output = script-output.log

--- a/condor_templates_test.go
+++ b/condor_templates_test.go
@@ -108,6 +108,9 @@ func TestGenerateCondorSubmit(t *testing.T) {
 executable = /usr/local/bin/road-runner
 rank = 100 - TotalLoadAvg
 requirements = (HAS_CYVERSE_ROAD_RUNNER =?= True) && (HAS_HOST_MOUNTS =?= True)
+request_cpus = 4.5
+request_memory = 2048MB
+request_disk = 2048MB
 arguments = --config config --job job
 output = script-output.log
 error = script-error.log
@@ -145,6 +148,9 @@ func TestGenerateCondorSubmitGroup(t *testing.T) {
 executable = /usr/local/bin/road-runner
 rank = 100 - TotalLoadAvg
 requirements = (HAS_CYVERSE_ROAD_RUNNER =?= True) && (HAS_HOST_MOUNTS =?= True)
+request_cpus = 4.5
+request_memory = 2048MB
+request_disk = 2048MB
 arguments = --config config --job job
 output = script-output.log
 error = script-error.log
@@ -181,6 +187,7 @@ func TestGenerateCondorSubmitNoVolumes(t *testing.T) {
 executable = /usr/local/bin/road-runner
 rank = 100 - TotalLoadAvg
 requirements = (HAS_CYVERSE_ROAD_RUNNER =?= True)
+request_memory = 2KB
 arguments = --config config --job job
 output = script-output.log
 error = script-error.log
@@ -203,5 +210,28 @@ queue
 `
 	if actual.String() != expected {
 		t.Errorf("GenerateCondorSubmit() returned:\n\n%s\n\ninstead of:\n\n%s", actual, expected)
+	}
+}
+
+func TestCondorBytes(t *testing.T) {
+	cases := []struct {
+		input  int64
+		output string
+	}{
+		{input: 400, output: "1KB"},
+		{input: 1024, output: "1KB"},
+		{input: 1000000, output: "977KB"},
+		{input: 1048576, output: "1MB"},
+		{input: 1000000000, output: "954MB"},
+		{input: 16000000000, output: "15259MB"},
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("%d", c.input), func(t *testing.T) {
+			output := CondorBytes(c.input)
+			if output != c.output {
+				t.Errorf("Got %s from input %d, expected %s", output, c.input, c.output)
+			}
+		})
 	}
 }

--- a/test/test_submission.json
+++ b/test/test_submission.json
@@ -12,8 +12,9 @@
                 "container":{
                     "name" : "test-name",
                     "network_mode" : "none",
-                    "cpu_shares" : 2048,
-                    "memory_limit" : 2048,
+                    "memory_limit" : 2147483648,
+                    "max_cpu_cores": 4.5,
+                    "min_disk_space": 2147483648,
                     "entrypoint" : "/bin/true",
                     "id":"16fd2a16-3ac6-11e5-a25d-2fa4b0893ef1",
                     "image":{


### PR DESCRIPTION
* Updates model to 4.1 so it has the stuff from my model PR for requests
* Adds a function to format int64 numbers of bytes as condor's expected strings. Rounds up to the nearest KiB through 1 MiB, then to the nearest MiB. (Yes, condor uses KB to mean KiB and MB to mean KiB)
* Uses said function to add `request_cpus`, `request_memory`, and `request_disk` to the submit file
* I also added `HasDocker` to the requirements while I was changing stuff, which will make it only send jobs to nodes where condor, at least, thinks docker works. We'll want to get better at watching for that -- if docker's working and condor is wrong, it just takes a `condor_reconfig` to have it pick it up.